### PR TITLE
Big bold beatiful RESH-CLI update

### DIFF
--- a/cmd/cli/highlight.go
+++ b/cmd/cli/highlight.go
@@ -27,6 +27,12 @@ func cleanHighlight(str string) string {
 	return str
 }
 
+func highlightStatus(str string) string {
+	invert := "\033[7;1m"
+	end := "\033[0m"
+	return invert + cleanHighlight(str) + end
+}
+
 func highlightSelected(str string) string {
 	// template "\033[3%d;%dm"
 	// invertGreen := "\033[32;7;1m"

--- a/cmd/cli/highlight.go
+++ b/cmd/cli/highlight.go
@@ -27,6 +27,13 @@ func cleanHighlight(str string) string {
 	return str
 }
 
+func highlightHeader(str string) string {
+	underline := "\033[4m"
+	end := "\033[0m"
+	// no clean highlight
+	return underline + str + end
+}
+
 func highlightStatus(str string) string {
 	invert := "\033[7;1m"
 	end := "\033[0m"
@@ -82,6 +89,13 @@ func highlightGit(str string) string {
 	greenBold := "\033[32;1m"
 	end := "\033[0m"
 	return greenBold + cleanHighlight(str) + end
+}
+
+func doHighlightHeader(str string, minLength int) string {
+	if len(str) < minLength {
+		str = str + strings.Repeat(" ", minLength-len(str))
+	}
+	return highlightHeader(str)
 }
 
 func doHighlightString(str string, minLength int) string {

--- a/cmd/cli/highlight.go
+++ b/cmd/cli/highlight.go
@@ -41,6 +41,13 @@ func highlightSelected(str string) string {
 	return invert + cleanHighlight(str) + end
 }
 
+func highlightDate(str string) string {
+	// template "\033[3%d;%dm"
+	yellowNormal := "\033[33m"
+	end := "\033[0m"
+	return yellowNormal + cleanHighlight(str) + end
+}
+
 func highlightHost(str string) string {
 	// template "\033[3%d;%dm"
 	redNormal := "\033[31m"

--- a/cmd/cli/item.go
+++ b/cmd/cli/item.go
@@ -65,68 +65,20 @@ func (i item) less(i2 item) bool {
 	// reversed order
 	return i.score > i2.score
 }
-
-func formatDatetime(tm time.Time) string {
-	tmSince := time.Since(tm)
-	hrs := tmSince.Hours()
-	yrs := int(hrs / (365 * 24))
-	if yrs > 0 {
-		if yrs == 1 {
-			return "1 year ago"
-		}
-		return strconv.Itoa(yrs) + " years ago"
-	}
-	months := int(hrs / (30 * 24))
-	if months > 0 {
-		if months == 1 {
-			return "1 month ago"
-		}
-		return strconv.Itoa(months) + " months ago"
-	}
-	days := int(hrs / 24)
-	if days > 0 {
-		if days == 1 {
-			return "1 day ago"
-		}
-		return strconv.Itoa(days) + " days ago"
-	}
-	hrsInt := int(hrs)
-	if hrsInt > 0 {
-		if hrsInt == 1 {
-			return "1 hour ago"
-		}
-		return strconv.Itoa(hrsInt) + " hours ago"
-	}
-	mins := int(hrs * 60)
-	if mins > 0 {
-		if mins == 1 {
-			return "1 min ago"
-		}
-		return strconv.Itoa(mins) + " mins ago"
-	}
-	secs := int(hrs * 60 * 60)
-	if secs > 0 {
-		if secs == 1 {
-			return "1 sec ago"
-		}
-		return strconv.Itoa(secs) + " secs ago"
-	}
-	return "now"
-}
-
-func (i item) drawItemColumns() itemColumns {
+func (i item) drawItemColumns(compactRendering bool) itemColumns {
 
 	// DISPLAY
 	// DISPLAY > date
 	secs := int64(i.realtimeBefore)
 	nsecs := int64((i.realtimeBefore - float64(secs)) * 1e9)
 	tm := time.Unix(secs, nsecs)
-	//date := tm.Format("2006-01-02 15:04 ")
-	// dateLength := len("12 months ago ") // longest date
-	date := formatDatetime(tm) + " "
-	// for len(date) < dateLength {
-	// 	date = " " + date
-	// }
+
+	var date string
+	if compactRendering {
+		date = formatTimeRelativeShort(tm) + " "
+	} else {
+		date = formatTimeRelativeLong(tm) + " "
+	}
 	dateWithColor := highlightDate(date)
 
 	// DISPLAY > location

--- a/cmd/cli/item.go
+++ b/cmd/cli/item.go
@@ -110,7 +110,7 @@ func (i item) drawStatusLine(compactRendering bool, printedLineLength, realLineL
 	pwdTilde := strings.Replace(i.pwd, i.home, "~", 1)
 
 	separator := "    "
-	stLine := timeString + separator + pwdTilde + separator + i.cmdLine
+	stLine := timeString + separator + i.host + ":" + pwdTilde + separator + i.cmdLine
 	return splitStatusLineToLines(stLine, printedLineLength, realLineLength)
 }
 

--- a/cmd/cli/item.go
+++ b/cmd/cli/item.go
@@ -115,6 +115,7 @@ func (i item) drawItemColumns(compactRendering bool) itemColumns {
 	if debug {
 		hitsStr := fmt.Sprintf("%.1f", i.score)
 		flags += " S" + hitsStr
+		flagsWithColor += " S" + hitsStr
 	}
 	if i.sameGitRepo {
 		flags += " G"
@@ -218,12 +219,12 @@ func properMatch(str, term, padChar string) bool {
 // newItemFromRecordForQuery creates new item from record based on given query
 //		returns error if the query doesn't match the record
 func newItemFromRecordForQuery(record records.CliRecord, query query, debug bool) (item, error) {
-	const hitScore = 1.0
+	const hitScore = 1.2
 	const hitScoreConsecutive = 0.1
 	const properMatchScore = 0.3
 	const actualPwdScore = 0.9
-	const nonZeroExitCodeScorePenalty = 0.5
-	const sameGitRepoScore = 0.7
+	const nonZeroExitCodeScorePenalty = 0.4
+	const sameGitRepoScore = 0.6
 	// const sameGitRepoScoreExtra = 0.0
 	const differentHostScorePenalty = 0.2
 

--- a/cmd/cli/item.go
+++ b/cmd/cli/item.go
@@ -64,46 +64,46 @@ func formatDatetime(tm time.Time) string {
 	tmSince := time.Since(tm)
 	hrs := tmSince.Hours()
 	yrs := int(hrs / (365 * 24))
-	if yrs > 1 {
+	if yrs > 0 {
+		if yrs == 1 {
+			return "1 year ago"
+		}
 		return strconv.Itoa(yrs) + " years ago"
 	}
-	if yrs == 1 {
-		return "1 year ago"
-	}
 	months := int(hrs / (30 * 24))
-	if months > 1 {
+	if months > 0 {
+		if months == 1 {
+			return "1 month ago"
+		}
 		return strconv.Itoa(months) + " months ago"
 	}
-	if months == 1 {
-		return "1 month ago"
-	}
 	days := int(hrs / 24)
-	if days > 1 {
+	if days > 0 {
+		if days == 1 {
+			return "1 day ago"
+		}
 		return strconv.Itoa(days) + " days ago"
 	}
-	if days == 1 {
-		return "1 day ago"
-	}
 	hrsInt := int(hrs)
-	if hrsInt > 1 {
+	if hrsInt > 0 {
+		if hrsInt == 1 {
+			return "1 hour ago"
+		}
 		return strconv.Itoa(hrsInt) + " hours ago"
 	}
-	if hrsInt == 1 {
-		return "1 hour ago"
-	}
 	mins := int(hrs * 60)
-	if mins > 1 {
+	if mins > 0 {
+		if mins == 1 {
+			return "1 min ago"
+		}
 		return strconv.Itoa(mins) + " mins ago"
 	}
-	if mins == 1 {
-		return "1 min ago"
-	}
 	secs := int(hrs * 60 * 60)
-	if secs > 1 {
+	if secs > 0 {
+		if secs == 1 {
+			return "1 sec ago"
+		}
 		return strconv.Itoa(secs) + " secs ago"
-	}
-	if secs == 1 {
-		return "1 sec ago"
 	}
 	return "now"
 }

--- a/cmd/cli/item.go
+++ b/cmd/cli/item.go
@@ -99,7 +99,7 @@ func splitStatusLineToLines(statusLine string, printedLineLength, realLineLength
 
 func (i item) drawStatusLine(compactRendering bool, printedLineLength, realLineLength int) []string {
 	if i.isRaw {
-		return splitStatusLineToLines(" "+i.cmdLine, printedLineLength, realLineLength)
+		return splitStatusLineToLines(i.cmdLine, printedLineLength, realLineLength)
 	}
 	secs := int64(i.realtimeBefore)
 	nsecs := int64((i.realtimeBefore - float64(secs)) * 1e9)

--- a/cmd/cli/item.go
+++ b/cmd/cli/item.go
@@ -6,13 +6,14 @@ import (
 	"log"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/curusarn/resh/pkg/records"
 )
 
 type item struct {
-	// dateWithColor string
-	// date          string
+	dateWithColor string
+	date          string
 
 	// [host:]pwd
 	locationWithColor string
@@ -36,8 +37,11 @@ func (i item) less(i2 item) bool {
 	return i.score > i2.score
 }
 
-func (i item) produceLine(flagLength int) (string, int) {
+func (i item) produceLine(flagLength int, showDate bool) (string, int) {
 	line := ""
+	if showDate {
+		line += i.dateWithColor
+	}
 	line += i.locationWithColor
 	line += i.flagsWithColor
 	flags := i.flags
@@ -167,7 +171,11 @@ func newItemFromRecordForQuery(record records.CliRecord, query query, debug bool
 
 	// DISPLAY
 	// DISPLAY > date
-	// TODO
+	secs := int64(record.RealtimeBeforeLocal)
+	nsecs := int64((record.RealtimeBeforeLocal - float64(secs)) * 1e9)
+	tm := time.Unix(secs, nsecs)
+	date := tm.Format("2006-01-02_15:04 ")
+	dateWithColor := highlightDate(date)
 
 	// DISPLAY > location
 	location := ""
@@ -213,6 +221,8 @@ func newItemFromRecordForQuery(record records.CliRecord, query query, debug bool
 	cmdLineWithColor := strings.ReplaceAll(cmd, "\n", ";")
 
 	it := item{
+		date:              date,
+		dateWithColor:     dateWithColor,
 		location:          location,
 		locationWithColor: locationWithColor,
 		flags:             flags,

--- a/cmd/cli/item.go
+++ b/cmd/cli/item.go
@@ -126,7 +126,7 @@ func (i item) drawItemColumns(compactRendering bool) itemColumns {
 	}
 }
 
-func (ic itemColumns) produceLine(dateLength int, locationLength int, flagLength int, showDate bool) (string, int) {
+func (ic itemColumns) produceLine(dateLength int, locationLength int, flagLength int, header bool, showDate bool) (string, int) {
 	line := ""
 	if showDate {
 		date := ic.date
@@ -156,7 +156,7 @@ func (ic itemColumns) produceLine(dateLength int, locationLength int, flagLength
 		flags += " "
 	}
 	spacer := "  "
-	if flagLength > 5 {
+	if flagLength > 5 || header {
 		// use shorter spacer
 		// 		because there is likely a long flag like E130 in the view
 		spacer = " "

--- a/cmd/cli/item.go
+++ b/cmd/cli/item.go
@@ -228,6 +228,7 @@ func newItemFromRecordForQuery(record records.CliRecord, query query, debug bool
 	// const sameGitRepoScoreExtra = 0.0
 	const differentHostScorePenalty = 0.2
 
+	const timeScoreCoef = 1e-13
 	// nonZeroExitCodeScorePenalty + differentHostScorePenalty
 
 	score := 0.0
@@ -307,6 +308,7 @@ func newItemFromRecordForQuery(record records.CliRecord, query query, debug bool
 	if score <= 0 && !anyHit {
 		return item{}, errors.New("no match for given record and query")
 	}
+	score += record.RealtimeBefore * timeScoreCoef
 
 	it := item{
 		realtimeBefore: record.RealtimeBefore,

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -487,8 +487,8 @@ func (m manager) normalMode(g *gocui.Gui, v *gocui.View) error {
 	topBoxHeight++    // headers
 	realLineLength := maxX - 2
 	printedLineLength := maxX - 4
-	selectedCommand := m.s.data[m.s.highlightedItem].cmdLine
-	var statusLineHeight int = len(selectedCommand)/(printedLineLength) + 1
+	statusLine := m.s.data[m.s.highlightedItem].drawStatusLine(compactRenderingMode, printedLineLength, realLineLength)
+	var statusLineHeight int = len(statusLine) + 1 // help line
 
 	helpLineHeight := 1
 	const helpLine = "HELP: type to search, UP/DOWN to select, RIGHT to edit, ENTER to execute, CTRL+G to abort, CTRL+C/D to quit; " +
@@ -536,29 +536,8 @@ func (m manager) normalMode(g *gocui.Gui, v *gocui.View) error {
 		v.WriteString("\n")
 		index++
 	}
-	// status line
-	var idxSt, idxEnd int
-	var nextLine bool
-	tab := "    "
-	tabSize := len(tab)
-	for idxSt < len(selectedCommand) {
-		idxEnd = idxSt + printedLineLength
-		if nextLine {
-			idxEnd -= tabSize
-		}
-
-		if idxEnd > len(selectedCommand) {
-			idxEnd = len(selectedCommand)
-		}
-		str := selectedCommand[idxSt:idxEnd]
-
-		indent := " "
-		if nextLine {
-			indent += tab
-		}
-		v.WriteString(highlightStatus(rightCutPadString(indent+str, realLineLength)) + "\n")
-		idxSt += printedLineLength
-		nextLine = true
+	for _, line := range statusLine {
+		v.WriteString(line)
 	}
 	v.WriteString(helpLine)
 	if debug {

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -453,12 +453,17 @@ func (m manager) normalMode(g *gocui.Gui, v *gocui.View) error {
 	longestDateLen := len(header.date)
 	longestLocationLen := len(header.host) + len(header.pwdTilde)
 	longestFlagsLen := 2
+	maxPossibleMainViewHeight := maxY - 3 - 1 - 1 - 1 // - top box - header - status - help
 	for i, itm := range m.s.data {
 		if i == maxY {
 			break
 		}
 		ic := itm.drawItemColumns(compactRenderingMode)
 		data = append(data, ic)
+		if i > maxPossibleMainViewHeight {
+			// do not stretch columns because of results that will end up outside of the page
+			continue
+		}
 		if len(ic.date) > longestDateLen {
 			longestDateLen = len(ic.date)
 		}
@@ -494,7 +499,7 @@ func (m manager) normalMode(g *gocui.Gui, v *gocui.View) error {
 
 	// header
 	// header := getHeader()
-	dispStr, _ := header.produceLine(longestDateLen, longestLocationLen, longestFlagsLen, true)
+	dispStr, _ := header.produceLine(longestDateLen, longestLocationLen, longestFlagsLen, true, true)
 	dispStr = doHighlightHeader(dispStr, maxX*2)
 	v.WriteString(dispStr + "\n")
 
@@ -506,7 +511,7 @@ func (m manager) normalMode(g *gocui.Gui, v *gocui.View) error {
 			break
 		}
 
-		displayStr, _ := itm.produceLine(longestDateLen, longestLocationLen, longestFlagsLen, true)
+		displayStr, _ := itm.produceLine(longestDateLen, longestLocationLen, longestFlagsLen, false, true)
 		if m.s.highlightedItem == index {
 			// maxX * 2 because there are escape sequences that make it hard to tell the real string lenght
 			displayStr = doHighlightString(displayStr, maxX*3)

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -434,18 +434,19 @@ func (m manager) normalMode(g *gocui.Gui, v *gocui.View) error {
 		m.s.highlightedItem = len(m.s.data) - 1
 	}
 	// status line
-	topBoxSize := 3 // size of the query box up top
+	topBoxHeight := 3 // size of the query box up top
 	realLineLength := maxX - 2
 	printedLineLength := maxX - 4
 	selectedCommand := m.s.data[m.s.highlightedItem].cmdLine
-	var selectedLineCount int = len(selectedCommand)/(printedLineLength) + 1
+	var statusLineHeight int = len(selectedCommand)/(printedLineLength) + 1
+	statusLineHeight++ // help line
 
-	m.s.displayedItemsCount = maxY - topBoxSize - selectedLineCount
+	m.s.displayedItemsCount = maxY - topBoxHeight - statusLineHeight
 
 	var index int
 	for index < len(data) {
 		itm := data[index]
-		if index == maxY-topBoxSize-selectedLineCount {
+		if index == maxY-topBoxHeight-statusLineHeight {
 			// page is full
 			break
 		}
@@ -471,7 +472,7 @@ func (m manager) normalMode(g *gocui.Gui, v *gocui.View) error {
 		index++
 	}
 	// push the status line to the bottom of the page
-	for index < maxY-topBoxSize-selectedLineCount {
+	for index < maxY-topBoxHeight-statusLineHeight {
 		v.WriteString("\n")
 		index++
 	}
@@ -499,6 +500,7 @@ func (m manager) normalMode(g *gocui.Gui, v *gocui.View) error {
 		idxSt += printedLineLength
 		nextLine = true
 	}
+	v.WriteString("HELP: type to search, UP/DOWN to select, RIGHT to edit, ENTER to execute, CTRL+G to abort, CTRL+C/D to quit")
 	if debug {
 		log.Println("len(data) =", len(m.s.data))
 		log.Println("highlightedItem =", m.s.highlightedItem)

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -430,13 +430,21 @@ func SendCliMsg(m msg.CliMsg, port string) msg.CliResponse {
 func (m manager) normalMode(g *gocui.Gui, v *gocui.View) error {
 	maxX, maxY := g.Size()
 
+	var data []itemColumns
+
+	longestDateLen := 0  // at least 0
 	longestFlagsLen := 2 // at least 2
 	for i, itm := range m.s.data {
 		if i == maxY {
 			break
 		}
-		if len(itm.flags) > longestFlagsLen {
-			longestFlagsLen = len(itm.flags)
+		ic := itm.drawItemColumns()
+		data = append(data, ic)
+		if len(ic.date) > longestDateLen {
+			longestDateLen = len(ic.date)
+		}
+		if len(ic.flags) > longestFlagsLen {
+			longestFlagsLen = len(ic.flags)
 		}
 	}
 
@@ -449,14 +457,14 @@ func (m manager) normalMode(g *gocui.Gui, v *gocui.View) error {
 
 	m.s.displayedItemsCount = maxY - topBoxSize - selectedLineCount
 
-	for i, itm := range m.s.data {
+	for i, itm := range data {
 		if i == maxY-topBoxSize-selectedLineCount {
 			if debug {
 				log.Println(maxY)
 			}
 			break
 		}
-		displayStr, _ := itm.produceLine(longestFlagsLen, true)
+		displayStr, _ := itm.produceLine(longestDateLen, longestFlagsLen, true)
 		if m.s.highlightedItem == i {
 			// maxX * 2 because there are escape sequences that make it hard to tell the real string lenght
 			displayStr = doHighlightString(displayStr, maxX*2)

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -156,11 +156,12 @@ func runReshCli() (string, int) {
 }
 
 type state struct {
-	lock            sync.Mutex
-	cliRecords      []records.CliRecord
-	data            []item
-	rawData         []rawItem
-	highlightedItem int
+	lock                sync.Mutex
+	cliRecords          []records.CliRecord
+	data                []item
+	rawData             []rawItem
+	highlightedItem     int
+	displayedItemsCount int
 
 	rawMode bool
 
@@ -316,10 +317,9 @@ func (m manager) Edit(v *gocui.View, key gocui.Key, ch rune, mod gocui.Modifier)
 }
 
 func (m manager) Next(g *gocui.Gui, v *gocui.View) error {
-	_, y := g.Size()
 	m.s.lock.Lock()
 	defer m.s.lock.Unlock()
-	if m.s.highlightedItem < y {
+	if m.s.highlightedItem < m.s.displayedItemsCount-1 {
 		m.s.highlightedItem++
 	}
 	return nil
@@ -447,6 +447,8 @@ func (m manager) normalMode(g *gocui.Gui, v *gocui.View) error {
 	selectedCommand := m.s.data[m.s.highlightedItem].cmdLine
 	var selectedLineCount int = len(selectedCommand)/(printedLineLength) + 1
 
+	m.s.displayedItemsCount = maxY - topBoxSize - selectedLineCount
+
 	for i, itm := range m.s.data {
 		if i == maxY-topBoxSize-selectedLineCount {
 			if debug {
@@ -509,6 +511,8 @@ func (m manager) normalMode(g *gocui.Gui, v *gocui.View) error {
 
 func (m manager) rawMode(g *gocui.Gui, v *gocui.View) error {
 	maxX, maxY := g.Size()
+	topBoxSize := 3
+	m.s.displayedItemsCount = maxY - topBoxSize
 
 	for i, itm := range m.s.rawData {
 		if i == maxY {

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -456,7 +456,7 @@ func (m manager) normalMode(g *gocui.Gui, v *gocui.View) error {
 			}
 			break
 		}
-		displayStr, _ := itm.produceLine(longestFlagsLen)
+		displayStr, _ := itm.produceLine(longestFlagsLen, true)
 		if m.s.highlightedItem == i {
 			// maxX * 2 because there are escape sequences that make it hard to tell the real string lenght
 			displayStr = doHighlightString(displayStr, maxX*2)

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -468,6 +468,7 @@ func (m manager) normalMode(g *gocui.Gui, v *gocui.View) error {
 	}
 	// status line
 	topBoxHeight := 3 // size of the query box up top
+	topBoxHeight++    // headers
 	realLineLength := maxX - 2
 	printedLineLength := maxX - 4
 	selectedCommand := m.s.data[m.s.highlightedItem].cmdLine

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -133,21 +133,23 @@ func runReshCli() (string, int) {
 	if err := g.SetKeybinding("", gocui.KeyCtrlP, gocui.ModNone, layout.Prev); err != nil {
 		log.Panicln(err)
 	}
+
+	if err := g.SetKeybinding("", gocui.KeyArrowRight, gocui.ModNone, layout.SelectPaste); err != nil {
+		log.Panicln(err)
+	}
+	if err := g.SetKeybinding("", gocui.KeyEnter, gocui.ModNone, layout.SelectExecute); err != nil {
+		log.Panicln(err)
+	}
+	if err := g.SetKeybinding("", gocui.KeyCtrlG, gocui.ModNone, layout.AbortPaste); err != nil {
+		log.Panicln(err)
+	}
 	if err := g.SetKeybinding("", gocui.KeyCtrlC, gocui.ModNone, quit); err != nil {
 		log.Panicln(err)
 	}
 	if err := g.SetKeybinding("", gocui.KeyCtrlD, gocui.ModNone, quit); err != nil {
 		log.Panicln(err)
 	}
-	if err := g.SetKeybinding("", gocui.KeyEnter, gocui.ModNone, layout.SelectExecute); err != nil {
-		log.Panicln(err)
-	}
-	if err := g.SetKeybinding("", gocui.KeyArrowRight, gocui.ModNone, layout.SelectPaste); err != nil {
-		log.Panicln(err)
-	}
-	if err := g.SetKeybinding("", gocui.KeyCtrlG, gocui.ModNone, layout.AbortPaste); err != nil {
-		log.Panicln(err)
-	}
+
 	if err := g.SetKeybinding("", gocui.KeyCtrlR, gocui.ModNone, layout.SwitchModes); err != nil {
 		log.Panicln(err)
 	}
@@ -439,14 +441,18 @@ func (m manager) normalMode(g *gocui.Gui, v *gocui.View) error {
 	printedLineLength := maxX - 4
 	selectedCommand := m.s.data[m.s.highlightedItem].cmdLine
 	var statusLineHeight int = len(selectedCommand)/(printedLineLength) + 1
-	statusLineHeight++ // help line
 
-	m.s.displayedItemsCount = maxY - topBoxHeight - statusLineHeight
+	helpLineHeight := 1
+	const helpLine = "HELP: type to search, UP/DOWN to select, RIGHT to edit, ENTER to execute, CTRL+G to abort, CTRL+C/D to quit; " +
+		"TIP: when resh-cli is launched command line is used as initial search query"
+
+	mainViewHeight := maxY - topBoxHeight - statusLineHeight - helpLineHeight
+	m.s.displayedItemsCount = mainViewHeight
 
 	var index int
 	for index < len(data) {
 		itm := data[index]
-		if index == maxY-topBoxHeight-statusLineHeight {
+		if index == mainViewHeight {
 			// page is full
 			break
 		}
@@ -472,7 +478,7 @@ func (m manager) normalMode(g *gocui.Gui, v *gocui.View) error {
 		index++
 	}
 	// push the status line to the bottom of the page
-	for index < maxY-topBoxHeight-statusLineHeight {
+	for index < mainViewHeight {
 		v.WriteString("\n")
 		index++
 	}
@@ -500,7 +506,7 @@ func (m manager) normalMode(g *gocui.Gui, v *gocui.View) error {
 		idxSt += printedLineLength
 		nextLine = true
 	}
-	v.WriteString("HELP: type to search, UP/DOWN to select, RIGHT to edit, ENTER to execute, CTRL+G to abort, CTRL+C/D to quit")
+	v.WriteString(helpLine)
 	if debug {
 		log.Println("len(data) =", len(m.s.data))
 		log.Println("highlightedItem =", m.s.highlightedItem)

--- a/cmd/cli/query.go
+++ b/cmd/cli/query.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"sort"
 	"strings"
 )
 
@@ -54,6 +55,7 @@ func newQueryFromString(queryInput string, host string, pwd string, gitOriginRem
 		log.Println("QUERY filtered terms =" + logStr)
 		log.Println("QUERY pwd =" + pwd)
 	}
+	sort.SliceStable(terms, func(i, j int) bool { return len(terms[i]) < len(terms[j]) })
 	return query{
 		terms:           terms,
 		host:            host,

--- a/cmd/cli/time.go
+++ b/cmd/cli/time.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"strconv"
+	"time"
+)
+
+func formatTimeRelativeLongest(tm time.Time) string {
+	tmSince := time.Since(tm)
+	hrs := tmSince.Hours()
+	yrs := int(hrs / (365 * 24))
+	if yrs > 0 {
+		if yrs == 1 {
+			return "1 year ago"
+		}
+		return strconv.Itoa(yrs) + " years ago"
+	}
+	months := int(hrs / (30 * 24))
+	if months > 0 {
+		if months == 1 {
+			return "1 month ago"
+		}
+		return strconv.Itoa(months) + " months ago"
+	}
+	days := int(hrs / 24)
+	if days > 0 {
+		if days == 1 {
+			return "1 day ago"
+		}
+		return strconv.Itoa(days) + " days ago"
+	}
+	hrsInt := int(hrs)
+	if hrsInt > 0 {
+		if hrsInt == 1 {
+			return "1 hour ago"
+		}
+		return strconv.Itoa(hrsInt) + " hours ago"
+	}
+	mins := int(hrs*60) % 60
+	if mins > 0 {
+		if mins == 1 {
+			return "1 min ago"
+		}
+		return strconv.Itoa(mins) + " mins ago"
+	}
+	secs := int(hrs*60*60) % 60
+	if secs > 0 {
+		if secs == 1 {
+			return "1 sec ago"
+		}
+		return strconv.Itoa(secs) + " secs ago"
+	}
+	return "now"
+}
+
+func formatTimeRelativeLong(tm time.Time) string {
+	tmSince := time.Since(tm)
+	hrs := tmSince.Hours()
+	yrs := int(hrs / (365 * 24))
+	if yrs > 0 {
+		if yrs == 1 {
+			return "1 year"
+		}
+		return strconv.Itoa(yrs) + " years"
+	}
+	months := int(hrs / (30 * 24))
+	if months > 0 {
+		if months == 1 {
+			return "1 month"
+		}
+		return strconv.Itoa(months) + " months"
+	}
+	days := int(hrs / 24)
+	if days > 0 {
+		if days == 1 {
+			return "1 day"
+		}
+		return strconv.Itoa(days) + " days"
+	}
+	hrsInt := int(hrs)
+	if hrsInt > 0 {
+		if hrsInt == 1 {
+			return "1 hour"
+		}
+		return strconv.Itoa(hrsInt) + " hours"
+	}
+	mins := int(hrs*60) % 60
+	if mins > 0 {
+		if mins == 1 {
+			return "1 min"
+		}
+		return strconv.Itoa(mins) + " mins"
+	}
+	secs := int(hrs*60*60) % 60
+	if secs > 0 {
+		if secs == 1 {
+			return "1 sec"
+		}
+		return strconv.Itoa(secs) + " secs"
+	}
+	return "now"
+}
+
+func formatTimeMixedLongest(tm time.Time) string {
+	tmSince := time.Since(tm)
+	hrs := tmSince.Hours()
+	yrs := int(hrs / (365 * 24))
+	if yrs > 0 {
+		if yrs == 1 {
+			return "1 year ago"
+		}
+		return strconv.Itoa(yrs) + " years ago"
+	}
+	months := int(hrs / (30 * 24))
+	if months > 0 {
+		if months == 1 {
+			return "1 month ago"
+		}
+		return strconv.Itoa(months) + " months ago"
+	}
+	days := int(hrs / 24)
+	if days > 0 {
+		if days == 1 {
+			return "1 day ago"
+		}
+		return strconv.Itoa(days) + " days ago"
+	}
+	hrsInt := int(hrs)
+	mins := int(hrs*60) % 60
+	return strconv.Itoa(hrsInt) + ":" + strconv.Itoa(mins)
+}
+
+func formatTimeRelativeShort(tm time.Time) string {
+	tmSince := time.Since(tm)
+	hrs := tmSince.Hours()
+	yrs := int(hrs / (365 * 24))
+	if yrs > 0 {
+		return strconv.Itoa(yrs) + " Y"
+	}
+	months := int(hrs / (30 * 24))
+	if months > 0 {
+		return strconv.Itoa(months) + " M"
+	}
+	days := int(hrs / 24)
+	if days > 0 {
+		return strconv.Itoa(days) + " D"
+	}
+	hrsInt := int(hrs)
+	if hrsInt > 0 {
+		return strconv.Itoa(hrsInt) + " h"
+	}
+	mins := int(hrs*60) % 60
+	if mins > 0 {
+		return strconv.Itoa(mins) + " m"
+	}
+	secs := int(hrs*60*60) % 60
+	if secs > 0 {
+		return strconv.Itoa(secs) + " s"
+	}
+	return "now"
+}
+
+func formatTimeMixedShort(tm time.Time) string {
+	tmSince := time.Since(tm)
+	hrs := tmSince.Hours()
+	yrs := int(hrs / (365 * 24))
+	if yrs > 0 {
+		return strconv.Itoa(yrs) + " Y"
+	}
+	months := int(hrs / (30 * 24))
+	if months > 0 {
+		return strconv.Itoa(months) + " M"
+	}
+	days := int(hrs / 24)
+	if days > 0 {
+		return strconv.Itoa(days) + " D"
+	}
+	hrsInt := int(hrs)
+	mins := int(hrs*60) % 60
+	return strconv.Itoa(hrsInt) + ":" + strconv.Itoa(mins)
+}

--- a/cmd/collect/main.go
+++ b/cmd/collect/main.go
@@ -53,6 +53,7 @@ func main() {
 	shell := flag.String("shell", "", "actual shell")
 	uname := flag.String("uname", "", "uname")
 	sessionID := flag.String("sessionId", "", "resh generated session id")
+	recordID := flag.String("recordId", "", "resh generated record id")
 
 	// recall metadata
 	recallActions := flag.String("recall-actions", "", "recall actions that took place before executing the command")
@@ -195,6 +196,7 @@ func main() {
 				Shell:     *shell,
 				Uname:     *uname,
 				SessionID: *sessionID,
+				RecordID:  *recordID,
 
 				// posix
 				Home:  *home,

--- a/cmd/postcollect/main.go
+++ b/cmd/postcollect/main.go
@@ -44,6 +44,8 @@ func main() {
 	cmdLine := flag.String("cmdLine", "", "command line")
 	exitCode := flag.Int("exitCode", -1, "exit code")
 	sessionID := flag.String("sessionId", "", "resh generated session id")
+	recordID := flag.String("recordId", "", "resh generated record id")
+
 	shlvl := flag.Int("shlvl", -1, "$SHLVL")
 	shell := flag.String("shell", "", "actual shell")
 
@@ -118,6 +120,7 @@ func main() {
 			CmdLine:   *cmdLine,
 			ExitCode:  *exitCode,
 			SessionID: *sessionID,
+			RecordID:  *recordID,
 			Shlvl:     *shlvl,
 			Shell:     *shell,
 

--- a/conf/config.toml
+++ b/conf/config.toml
@@ -4,4 +4,4 @@ sesshistInitHistorySize = 1000
 debug = false 
 bindArrowKeysBash = false
 bindArrowKeysZsh = true
-bindControlR = false
+bindControlR = true

--- a/pkg/histcli/histcli.go
+++ b/pkg/histcli/histcli.go
@@ -22,3 +22,10 @@ func (h *Histcli) AddRecord(record records.Record) {
 
 	h.List = append(h.List, cli)
 }
+
+// AddCmdLine to the histcli
+func (h *Histcli) AddCmdLine(cmdline string) {
+	cli := records.NewCliRecordFromCmdLine(cmdline)
+
+	h.List = append(h.List, cli)
+}

--- a/pkg/histfile/histfile.go
+++ b/pkg/histfile/histfile.go
@@ -50,7 +50,13 @@ func New(input chan records.Record, sessionsToDrop chan string,
 }
 
 // load records from resh history, reverse, enrich and save
-func (h *Histfile) loadFullRecords(recs []records.Record) {
+func (h *Histfile) loadCliRecords(recs []records.Record) {
+	for _, cmdline := range h.bashCmdLines.List {
+		h.cliRecords.AddCmdLine(cmdline)
+	}
+	for _, cmdline := range h.zshCmdLines.List {
+		h.cliRecords.AddCmdLine(cmdline)
+	}
 	for i := len(recs) - 1; i >= 0; i-- {
 		rec := recs[i]
 		h.cliRecords.AddRecord(rec)
@@ -82,7 +88,7 @@ func (h *Histfile) loadHistory(bashHistoryPath, zshHistoryPath string, maxInitHi
 	}
 	log.Println("histfile: Loading resh history from file ...")
 	history := records.LoadFromFile(h.historyPath, math.MaxInt32)
-	go h.loadFullRecords(history)
+	go h.loadCliRecords(history)
 	// NOTE: keeping this weird interface for now because we might use it in the future
 	//			when we only load bash or zsh history
 	reshCmdLines := loadCmdLines(history)

--- a/pkg/records/records.go
+++ b/pkg/records/records.go
@@ -23,6 +23,7 @@ type BaseRecord struct {
 	Shell     string `json:"shell"`
 	Uname     string `json:"uname"`
 	SessionID string `json:"sessionId"`
+	RecordID  string `json:"recordId"`
 
 	// posix
 	Home  string `json:"home"`
@@ -231,6 +232,9 @@ func (r *Record) Merge(r2 Record) error {
 	}
 	if r.CmdLine != r2.CmdLine {
 		return errors.New("Records to merge are not parts of the same records - r1:" + r.CmdLine + " r2:" + r2.CmdLine)
+	}
+	if r.RecordID != r2.RecordID {
+		return errors.New("Records to merge do not have the same ID - r1:" + r.RecordID + " r2:" + r2.RecordID)
 	}
 	// r.RealtimeBefore != r2.RealtimeBefore - can't be used because of bash-preexec runs when it's not supposed to
 	r.ExitCode = r2.ExitCode

--- a/pkg/records/records.go
+++ b/pkg/records/records.go
@@ -150,6 +150,7 @@ type SlimRecord struct {
 
 // CliRecord used for sending records to RESH-CLI
 type CliRecord struct {
+	IsRaw     bool   `json:"isRaw"`
 	SessionID string `json:"sessionId"`
 
 	CmdLine         string `json:"cmdLine"`
@@ -164,9 +165,18 @@ type CliRecord struct {
 	// RealtimeDuration float64 `json:"realtimeDuration"`
 }
 
+// NewCliRecordFromCmdLine from EnrichedRecord
+func NewCliRecordFromCmdLine(cmdLine string) CliRecord {
+	return CliRecord{
+		IsRaw:   true,
+		CmdLine: cmdLine,
+	}
+}
+
 // NewCliRecord from EnrichedRecord
 func NewCliRecord(r EnrichedRecord) CliRecord {
 	return CliRecord{
+		IsRaw:           false,
 		SessionID:       r.SessionID,
 		CmdLine:         r.CmdLine,
 		Host:            r.Host,

--- a/pkg/records/records.go
+++ b/pkg/records/records.go
@@ -158,7 +158,7 @@ type CliRecord struct {
 	GitOriginRemote string `json:"gitOriginRemote"`
 	ExitCode        int    `json:"exitCode"`
 
-	RealtimeBeforeLocal float64 `json:"realtimeBeforeLocal"`
+	RealtimeBefore float64 `json:"realtimeBefore"`
 	// RealtimeAfter    float64 `json:"realtimeAfter"`
 	// RealtimeDuration float64 `json:"realtimeDuration"`
 }
@@ -166,14 +166,14 @@ type CliRecord struct {
 // NewCliRecord from EnrichedRecord
 func NewCliRecord(r EnrichedRecord) CliRecord {
 	return CliRecord{
-		SessionID:           r.SessionID,
-		CmdLine:             r.CmdLine,
-		Host:                r.Host,
-		Pwd:                 r.Pwd,
-		Home:                r.Home,
-		GitOriginRemote:     r.GitOriginRemote,
-		ExitCode:            r.ExitCode,
-		RealtimeBeforeLocal: r.RealtimeBeforeLocal,
+		SessionID:       r.SessionID,
+		CmdLine:         r.CmdLine,
+		Host:            r.Host,
+		Pwd:             r.Pwd,
+		Home:            r.Home,
+		GitOriginRemote: r.GitOriginRemote,
+		ExitCode:        r.ExitCode,
+		RealtimeBefore:  r.RealtimeBefore,
 	}
 }
 

--- a/pkg/records/records.go
+++ b/pkg/records/records.go
@@ -158,7 +158,7 @@ type CliRecord struct {
 	GitOriginRemote string `json:"gitOriginRemote"`
 	ExitCode        int    `json:"exitCode"`
 
-	// RealtimeBefore   float64 `json:"realtimeBefore"`
+	RealtimeBeforeLocal float64 `json:"realtimeBeforeLocal"`
 	// RealtimeAfter    float64 `json:"realtimeAfter"`
 	// RealtimeDuration float64 `json:"realtimeDuration"`
 }
@@ -166,13 +166,14 @@ type CliRecord struct {
 // NewCliRecord from EnrichedRecord
 func NewCliRecord(r EnrichedRecord) CliRecord {
 	return CliRecord{
-		SessionID:       r.SessionID,
-		CmdLine:         r.CmdLine,
-		Host:            r.Host,
-		Pwd:             r.Pwd,
-		Home:            r.Home,
-		GitOriginRemote: r.GitOriginRemote,
-		ExitCode:        r.ExitCode,
+		SessionID:           r.SessionID,
+		CmdLine:             r.CmdLine,
+		Host:                r.Host,
+		Pwd:                 r.Pwd,
+		Home:                r.Home,
+		GitOriginRemote:     r.GitOriginRemote,
+		ExitCode:            r.ExitCode,
+		RealtimeBeforeLocal: r.RealtimeBeforeLocal,
 	}
 }
 

--- a/scripts/hooks.sh
+++ b/scripts/hooks.sh
@@ -9,6 +9,7 @@ __resh_reset_variables() {
     __RESH_HIST_RECALL_ACTIONS=""
     __RESH_HIST_NO_PREFIX_MODE=0
     __RESH_HIST_RECALL_STRATEGY=""
+    __RESH_RECORD_ID=$(__resh_get_uuid)
 }
 
 __resh_preexec() {
@@ -81,6 +82,7 @@ __resh_collect() {
                     -shell "$__RESH_SHELL" \
                     -uname "$__RESH_UNAME" \
                     -sessionId "$__RESH_SESSION_ID" \
+                    -recordId "$__RESH_RECORD_ID" \
                     -cols "$__RESH_COLS" \
                     -home "$__RESH_HOME" \
                     -lang "$__RESH_LANG" \
@@ -157,6 +159,7 @@ __resh_precmd() {
                         -realtimeBefore "$__RESH_RT_BEFORE" \
                         -exitCode "$__RESH_EXIT_CODE" \
                         -sessionId "$__RESH_SESSION_ID" \
+                        -recordId "$__RESH_RECORD_ID" \
                         -shell "$__RESH_SHELL" \
                         -shlvl "$__RESH_SHLVL" \
                         -pwdAfter "$__RESH_PWD_AFTER" \


### PR DESCRIPTION
## Visual improvements
- use standard shell history (when there is not enough of resh history)
- add a column with time/date
- add headers for columns
- add a status line with info without any shortening
- show help near bottom of the screen

## Other improvements
- speed up typing and searching
- add new keybindings
    - Ctrl+P/N works as arrow up/down
    - Ctrl+G aborts the app and pastes the query on the command line
- update search function weights
- misc improvements and fixes 
- Ctrl+R now launches RESH-CLI by default (for new installs)
