### PR TITLE
Fix overlap in folded strings

### DIFF
--- a/pkg/searchapp/item.go
+++ b/pkg/searchapp/item.go
@@ -241,23 +241,23 @@ func (ic ItemColumns) ProduceLine(dateLength int, locationLength int, flagLength
 }
 
 func leftCutPadString(str string, newLen int) string {
-	dots := "…"
+	dots := "… "
 	strLen := len(str)
 	if newLen > strLen {
 		return strings.Repeat(" ", newLen-strLen) + str
 	} else if newLen < strLen {
-		return dots + str[strLen-newLen+1:]
+		return dots + str[strLen-newLen+2:]
 	}
 	return str
 }
 
 func rightCutPadString(str string, newLen int) string {
-	dots := "…"
+	dots := " …"
 	strLen := len(str)
 	if newLen > strLen {
 		return str + strings.Repeat(" ", newLen-strLen)
 	} else if newLen < strLen {
-		return str[:newLen-1] + dots
+		return str[:newLen-2] + dots
 	}
 	return str
 }


### PR DESCRIPTION
The current implementation overlaps dot strings with original strings.

Font: Ricty Nerd Font
Terminal: Alacritty

This PR fixes the problem.

**Before:**

![Screenshot 2020-05-26 at 14 43 25](https://user-images.githubusercontent.com/21333876/82864802-5762f000-9f60-11ea-9c75-f81d6128d4c1.png)

**After:**

![Screenshot 2020-05-26 at 14 41 49](https://user-images.githubusercontent.com/21333876/82864868-7c576300-9f60-11ea-8b21-01243e477ad8.png)
