### PR TITLE
update go version to 1.16 and goreleaser to support M1 macOS (arm64)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,12 +17,12 @@ jobs:
         run: git submodule update --init --recursive 
       -
         name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
-          go-version: '1.12'
+          go-version: 1.16
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v1
+        uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
           args: release

--- a/scripts/rawinstall.sh
+++ b/scripts/rawinstall.sh
@@ -68,9 +68,9 @@ arm64|aarch64*|armv8*)
 esac
 
 if [ "$OS" = darwin ]; then
-    if [ "$ARCH" = armv6 ] || [ "$ARCH" = arm64 ]; then
-        echo "It seems that you are running macOS on arm - exiting!"
-        echo "Expected Linux or macOS on x86_64 or i386 (or Linux on arm or arm64)"
+    if [ "$ARCH" = armv6 ] ; then
+        echo "It seems that you are running macOS on armv6 - exiting!"
+        echo "Expected Linux or macOS on x86_64 or i386 (or Linux on arm or arm64 or macOS on arm64)"
         echo "Got OS: $(uname) (uname)"
         echo "Got ARCH: $(uname -m) (uname -m)"
         exit 1


### PR DESCRIPTION
closes https://github.com/curusarn/resh/issues/158

This should be sufficient for M1 MacBooks - not tested